### PR TITLE
fixed directory name issue and removed hello world (no pubspec)

### DIFF
--- a/pub_get.sh
+++ b/pub_get.sh
@@ -4,8 +4,7 @@ cd counter_app && flutter packages get && cd .. &&
 cd dart_pos &&  pub get && cd .. &&
 cd dart_pos_end &&  pub get && cd .. &&
 cd e_commerce_complete &&  flutter packages get && cd .. &&
-cd flutter_firebase_complete &&  flutter packages get && cd .. &&
-cd hello_word_dart && pub get && cd .. &&
+cd flutter_firebase_repository &&  flutter packages get && cd .. &&
 cd shared_lib && pub get && pub run build_runner build && cd .. &&
 cd weather_app_complete && flutter pub get && cd .. &&
 cd weather_app_start_chapter_5 && flutter pub get && cd .. &&


### PR DESCRIPTION
ran the pub_get.sh script and found a couple of issues. the firebase subdir name was incorrect, and the hello-world subdir doesn't have a pubspec

also, when the firebase subdir 'pub get' runs, i see this:
[INFO] Found 5 declared outputs which already exist on disk. This is likely because the`.dart_tool/build` folder was deleted, or you are submitting generated files to your source repository.
Delete these files?
1 - Delete
2 - Cancel build
3 - List conflicts

i picked 1 and all worked well, but since i'm mostly a dumb keyboard at this point dunno why